### PR TITLE
Add bottom navigation with center home

### DIFF
--- a/lib/core/screens/main_tabs_screen.dart
+++ b/lib/core/screens/main_tabs_screen.dart
@@ -1,24 +1,73 @@
-import 'package:buillient_app/app_router.dart';
+import 'package:buillient_app/home/screens/home_screen.dart';
+import 'package:buillient_app/news/screens/news_screen.dart';
+import 'package:buillient_app/trading/screens/trading_screen.dart';
+import 'package:buillient_app/settings/screens/settings_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:auto_route/auto_route.dart';
 
-@RoutePage()
-class MainTabsScreen extends StatelessWidget {
+class MainTabsScreen extends StatefulWidget {
   const MainTabsScreen({super.key});
 
   @override
+  State<MainTabsScreen> createState() => _MainTabsScreenState();
+}
+
+class _MainTabsScreenState extends State<MainTabsScreen> {
+  int _currentIndex = 1;
+
+  final List<Widget> _pages = const [
+    NewsScreen(),
+    HomeScreen(),
+    TradingScreen(),
+    SettingsScreen(),
+  ];
+
+  void _selectTab(int index) {
+    setState(() => _currentIndex = index);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return AutoTabsRouter.pageView(
-      routes: const [
-        HomeRoute(),
-      ],
-      builder: (context, child, animation) {
-        final tabsRouter = AutoTabsRouter.of(context);
-        return Scaffold(
-          body: child,
-          // ✅ Builder로 감싸서 HomeScreen을 포함하는 context 확보
-        );
-      },
+    return Scaffold(
+      body: _pages[_currentIndex],
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _selectTab(1),
+        backgroundColor: _currentIndex == 1
+            ? Theme.of(context).colorScheme.primary
+            : null,
+        child: const Icon(Icons.home),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      bottomNavigationBar: BottomAppBar(
+        shape: const CircularNotchedRectangle(),
+        notchMargin: 6,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.article),
+              color: _currentIndex == 0
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+              onPressed: () => _selectTab(0),
+            ),
+            const SizedBox(width: 48),
+            IconButton(
+              icon: const Icon(Icons.trending_up),
+              color: _currentIndex == 2
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+              onPressed: () => _selectTab(2),
+            ),
+            IconButton(
+              icon: const Icon(Icons.settings),
+              color: _currentIndex == 3
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+              onPressed: () => _selectTab(3),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/home/screens/home_screen.dart
+++ b/lib/home/screens/home_screen.dart
@@ -7,9 +7,54 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final List<Map<String, String>> articles = [
+      {
+        'title': 'Flutter 4 출시',
+        'description': '새로운 기능과 개선 사항이 포함된 Flutter 4가 공개되었습니다.',
+      },
+      {
+        'title': '개발자 컨퍼런스 2024 개최',
+        'description': '전 세계 개발자들이 모여 크로스 플랫폼 앱의 미래를 논의합니다.',
+      },
+      {
+        'title': 'AI 기술의 진화',
+        'description': '인공지능이 생활 곳곳에 적용되며 빠르게 발전하고 있습니다.',
+      },
+    ];
+
     return Scaffold(
       appBar: AppBar(title: const Text('홈 화면')),
-      body: const Center(child: Text('여기가 홈이에요!')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            '최신 뉴스',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          Card(
+            color: Theme.of(context).colorScheme.primaryContainer,
+            child: ListTile(
+              title: Text(articles.first['title']!),
+              subtitle: Text(articles.first['description']!),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            '다른 뉴스',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          ...articles.skip(1).map(
+            (article) => Card(
+              child: ListTile(
+                title: Text(article['title']!),
+                subtitle: Text(article['description']!),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'core/screens/main_tabs_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,93 +31,7 @@ class MyApp extends StatelessWidget {
         // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const MainTabsScreen(),
     );
   }
 }

--- a/lib/news/screens/news_screen.dart
+++ b/lib/news/screens/news_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class NewsScreen extends StatelessWidget {
+  const NewsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('뉴스')),
+      body: const Center(child: Text('뉴스 화면')),
+    );
+  }
+}

--- a/lib/settings/screens/settings_screen.dart
+++ b/lib/settings/screens/settings_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('설정')),
+      body: const Center(child: Text('설정 화면')),
+    );
+  }
+}

--- a/lib/trading/screens/trading_screen.dart
+++ b/lib/trading/screens/trading_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class TradingScreen extends StatelessWidget {
+  const TradingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('트레이딩')),
+      body: const Center(child: Text('트레이딩 화면')),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create simple placeholder screens for news, trading and settings
- implement bottom navigation in `MainTabsScreen` with a centered home button
- launch `MainTabsScreen` on startup

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685f9caef91c832db9cbe321bfca0fea